### PR TITLE
Fix blurry text in canvas

### DIFF
--- a/Assets/Plugins/Editor.meta
+++ b/Assets/Plugins/Editor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: dd9716bd20f55913b8597fd733954a27
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/CopyrightScene.unity
+++ b/Assets/Scenes/CopyrightScene.unity
@@ -298,7 +298,7 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 12800000, guid: 9136c7fb4047862f98eb183b5699677d, type: 3}
+    m_Font: {fileID: 12800000, guid: f5885b4b30625ac7abade3e1f5020ee3, type: 3}
     m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 0
@@ -476,7 +476,7 @@ MonoBehaviour:
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
+  m_DynamicPixelsPerUnit: 10
 --- !u!223 &693476441
 Canvas:
   m_ObjectHideFlags: 0
@@ -1210,7 +1210,7 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 12800000, guid: 9136c7fb4047862f98eb183b5699677d, type: 3}
+    m_Font: {fileID: 12800000, guid: f5885b4b30625ac7abade3e1f5020ee3, type: 3}
     m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 0
@@ -1289,7 +1289,7 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_Font: {fileID: 12800000, guid: f5885b4b30625ac7abade3e1f5020ee3, type: 3}
     m_FontSize: 5
     m_FontStyle: 0
     m_BestFit: 0

--- a/Assets/Scenes/WelcomeScene.unity
+++ b/Assets/Scenes/WelcomeScene.unity
@@ -780,12 +780,12 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 12800000, guid: 9136c7fb4047862f98eb183b5699677d, type: 3}
+    m_Font: {fileID: 12800000, guid: f5885b4b30625ac7abade3e1f5020ee3, type: 3}
     m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
+    m_MinSize: 0
+    m_MaxSize: 255
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -924,12 +924,12 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 12800000, guid: 9136c7fb4047862f98eb183b5699677d, type: 3}
+    m_Font: {fileID: 12800000, guid: f5885b4b30625ac7abade3e1f5020ee3, type: 3}
     m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
+    m_MinSize: 0
+    m_MaxSize: 300
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -1028,7 +1028,7 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 12800000, guid: 9136c7fb4047862f98eb183b5699677d, type: 3}
+    m_Font: {fileID: 12800000, guid: f5885b4b30625ac7abade3e1f5020ee3, type: 3}
     m_FontSize: 14
     m_FontStyle: 0
     m_BestFit: 0
@@ -1518,7 +1518,7 @@ MonoBehaviour:
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
+  m_DynamicPixelsPerUnit: 10
 --- !u!223 &1936453116
 Canvas:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Set the "Dynamic Pixels Per Unit" value to 10 to sharpen the font.

プロバティ「Dynamic Pixels Per Unit」に「10」の値を付けてぼやけたフォントをフィックスします。

Source: https://answers.unity.com/questions/990559/fix-blurry-ui-text.html